### PR TITLE
Fix: Update facilities based on user location

### DIFF
--- a/src/components/Button/SportButton/SportButton.module.scss
+++ b/src/components/Button/SportButton/SportButton.module.scss
@@ -19,7 +19,9 @@
   align-items: center;
   justify-content: center;
   margin-bottom: 8px;
-  transition: background-color 0.3s ease, transform 0.2s ease;
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease;
 
   &:hover {
     background-color: $gray30;
@@ -40,8 +42,9 @@
 
 .label {
   margin-top: 8px;
-  @include C12M;
+  @include B14R;
   color: $gray90;
   text-align: center;
   transition: color 0.2s ease;
+  white-space: nowrap;
 }

--- a/src/components/Lesson/index.tsx
+++ b/src/components/Lesson/index.tsx
@@ -34,19 +34,20 @@ export default function Lesson() {
   );
   const [selectedSport, setSelectedSport] = useRecoilState(selectedSportState);
 
-  // 초기 데이터 로드
+  // 초기 데이터 로드 (localCode가 없으면 기본값으로 '11110' 설정)
   useEffect(() => {
     const fetchInitialFacilities = async () => {
+      const initialLocalCode = selectedLocalCode || localStorage.getItem('localCode') || '11110';
+      if (!selectedLocalCode) setSelectedLocalCode(initialLocalCode);
+
       try {
         const params: GetFacilitiesParams = {
-          localCode: selectedLocalCode,
+          localCode: initialLocalCode,
         };
 
         const fetchedFacilities = await getFacilities(params);
-        setFacilities(
-          filterFacilitiesBySport(fetchedFacilities, selectedSport)
-        );
-        setCurrentOptions(localCodes[selectedCityCode]);
+        setFacilities(filterFacilitiesBySport(fetchedFacilities, selectedSport));
+        setCurrentOptions(localCodes[selectedCityCode] || {});
       } catch {
         console.error('초기 시설 데이터를 불러오는 데 실패했습니다.');
       }
@@ -73,6 +74,7 @@ export default function Lesson() {
   const handleValueChange = (key: string) => {
     if (isNextStep) {
       setSelectedLocalCode(key);
+      localStorage.setItem('localCode', key); // 로컬 스토리지에 로컬 코드 저장 => 확인 
     } else {
       setSelectedCityCode(key);
     }

--- a/src/components/MapHome/PopularSports/PopularSports.module.scss
+++ b/src/components/MapHome/PopularSports/PopularSports.module.scss
@@ -43,8 +43,7 @@
 }
 
 .title {
-  @include B16M;
-  font-weight: 600;
+  @include T16B;
   color: $gray90;
   align-self: flex-start;
   margin-bottom: 16px;

--- a/src/components/MapHome/PopularSports/PopularSports.module.scss
+++ b/src/components/MapHome/PopularSports/PopularSports.module.scss
@@ -52,7 +52,7 @@
 
 .sportsList {
   display: flex;
-  gap: 16px;
+  gap: 8px;
   justify-content: center;
   width: 100%;
 }

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -32,7 +32,7 @@ export default function Map() {
   const [map, setMap] = useState<any>(null);
   const [selectedMarker, setSelectedMarker] = useState<any>(null);
   const [userLocation, setUserLocation] = useState<any>(null);
-  const [localCode, setLocalCode] = useState<string | null>(null);
+  const [localCode, setLocalCode] = useState<string>('11110'); // 기본값을 서울 종로구 '11110'으로 설정
 
   useEffect(() => {
     document.body.style.overflow = 'hidden';
@@ -45,7 +45,7 @@ export default function Map() {
   const fetchFacilitiesBySport = async (sport: string | null = null) => {
     try {
       const data = await getFacilities({
-        localCode: localCode || '11680', // 로컬 코드가 없으면 기본값으로 '11680' 사용
+        localCode: localCode || '11110', // 로컬 코드가 없으면 '11110' 사용
         itemName: sport || undefined,
       });
       setFacilities(data);
@@ -54,7 +54,6 @@ export default function Map() {
     }
   };
 
-  // 로컬 코드와 시설 데이터를 현재 위치 기반으로 설정
   const updateLocalCodeAndFetchFacilities = (
     latitude: number,
     longitude: number
@@ -65,7 +64,9 @@ export default function Map() {
       latitude,
       (result: any, status: string) => {
         if (status === window.kakao.maps.services.Status.OK && result[0].code) {
-          setLocalCode(result[0].code); // API에서 받은 로컬 코드로 상태 업데이트
+          const newLocalCode = result[0].code || '11110'; // 실패 시 '11110'로 기본 설정
+          setLocalCode(newLocalCode);
+          localStorage.setItem('localCode', newLocalCode); // 로컬 스토리지에 지역 코드 저장
           fetchFacilitiesBySport(); // 새로 설정된 로컬 코드에 맞춰 시설 데이터 로드
         }
       }
@@ -89,7 +90,6 @@ export default function Map() {
         const kakaoMap = new window.kakao.maps.Map(mapContainer, mapOption);
         setMap(kakaoMap);
 
-        // 사용자 위치 표시와 로컬 코드 설정
         if (navigator.geolocation) {
           navigator.geolocation.getCurrentPosition(
             position => {

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -34,6 +34,13 @@ export default function Map() {
   const [userLocation, setUserLocation] = useState<any>(null);
   const [localCode, setLocalCode] = useState<string>('11110'); // 기본값으로 서울 종로구 설정
 
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, []);
+
   const fetchFacilitiesBySport = async (sport: string | null = null) => {
     try {
       setFacilities([]); // 기존 시설 목록 초기화

--- a/src/pages/map/index.tsx
+++ b/src/pages/map/index.tsx
@@ -34,11 +34,11 @@ export default function Map() {
   const [userLocation, setUserLocation] = useState<any>(null);
   const [localCode, setLocalCode] = useState<string>('11110'); // 기본값으로 서울 종로구 설정
 
-  // 시설 정보를 특정 스포츠 종목과 지역 코드에 맞게 가져오기
   const fetchFacilitiesBySport = async (sport: string | null = null) => {
     try {
+      setFacilities([]); // 기존 시설 목록 초기화
       const data = await getFacilities({
-        localCode: localCode || '11110', // 로컬 코드가 없으면 기본값 사용
+        localCode: localCode || '11110', // 로컬 코드가 없으면 기본값 사용 (서울 종로구)
         itemName: sport || undefined,
       });
       setFacilities(data);
@@ -47,7 +47,6 @@ export default function Map() {
     }
   };
 
-  // 사용자 위치 기반으로 지역 코드를 가져오고 시설 데이터를 업데이트
   const updateLocalCodeAndFetchFacilities = (
     latitude: number,
     longitude: number
@@ -62,13 +61,11 @@ export default function Map() {
           const shortLocalCode = fullLocalCode.slice(0, 5); // 앞 5자리만 사용
           setLocalCode(shortLocalCode); // 로컬 코드 상태 업데이트
           localStorage.setItem('localCode', shortLocalCode); // 로컬 스토리지에 저장
-          fetchFacilitiesBySport(); // 새로 설정된 로컬 코드에 맞춰 시설 데이터 로드
         }
       }
     );
   };
 
-  // 지도 초기화 및 사용자 위치 설정
   useEffect(() => {
     const mapScript = document.createElement('script');
     mapScript.async = true;
@@ -128,7 +125,10 @@ export default function Map() {
     };
   }, [KAKAO_MAP_KEY]);
 
-  // 시설 데이터에 따른 마커 표시
+  useEffect(() => {
+    fetchFacilitiesBySport();
+  }, [localCode]);
+
   useEffect(() => {
     if (!map || facilities.length === 0) return;
 

--- a/src/states/filterState.ts
+++ b/src/states/filterState.ts
@@ -7,7 +7,7 @@ export const selectedCityCodeState = atom<string>({
 
 export const selectedLocalCodeState = atom<string>({
   key: 'selectedLocalCodeState',
-  default: '11680', // 서울 강남구
+  default: '11110', // 서울 종로구
 });
 
 export const selectedSportState = atom<string>({

--- a/src/states/locationState.ts
+++ b/src/states/locationState.ts
@@ -1,0 +1,14 @@
+import { atom } from 'recoil';
+
+export const userCoordinatesState = atom<{
+  latitude: number;
+  longitude: number;
+} | null>({
+  key: 'userCoordinatesState',
+  default: null,
+});
+
+export const userLocationCodeState = atom<string>({
+  key: 'userLocationCodeState',
+  default: '11110', // 초기값으로 기본 지역 코드 설정 (서울 종로구)
+});


### PR DESCRIPTION
### 🔎 작업 내용
- [x] 지도 홈(/map)에서 사용자 위치를 읽어 로컬 스토리지와 Recoil 상태에 저장함
- [x] 강좌 탭(/lesson)에 들어가면 Recoil에서 사용자 좌표를 가져옴
- [x] 가져온 좌표를 이용해 해당 지역을 구하고 지역 코드를 변환함
- [x] 변환한 지역 코드를 필터에 반영하여 해당 지역의 시설이나 강좌를 필터링함
======================================================
- [x] 사용자의 현재 위치 데이터가 제공되는 경우 해당 지역의 시설 표시 / 아닐 경우 디폴트 지역(**서울 종로구**) 시설 표시

### 📸 스크린샷
### 사용자 위치 기반
![image](https://github.com/user-attachments/assets/7ff708b0-2b37-4852-839b-db7ca4a8ff53)

### 디폴트
![초기 상태(서울 종로구 디폴트)](https://github.com/user-attachments/assets/bb91e26e-d367-43ed-90b3-c141fdbf1ba0)

### local storage
![로컬 스토리지](https://github.com/user-attachments/assets/96a08d86-5479-4e9f-9ba9-cf2becf521ba)

### 필터 확인
![로컬 코드 전달 확인](https://github.com/user-attachments/assets/e8208d48-5798-44a6-800d-8660c05c6a22)


### :loudspeaker: 전달사항
 - 테스트에 어려움이 있어서 사용자의 위치 정보가 없을 경우 디폴트 지역 코드를 **"서울 종로구 (11110)"** 로 수정했습니다!
 - /map에서 dropdown 대신에 만들어두신 local filter 컴포넌트 재사용하겠습니다 (_ _) UI 확인은 되어 데이터만... 어찌 하면 될듯...
