### PR TITLE
Fix: 사용자 위치 정보로 강좌 지역 필터 세팅

### DIFF
--- a/src/components/Button/LikeButton/index.tsx
+++ b/src/components/Button/LikeButton/index.tsx
@@ -35,7 +35,7 @@ export default function LikeButton({
   }, [businessId, serialNumber]);
 
   const handleClick = async () => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem('access_token');
     if (!token) {
       showModal();
       return;

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -56,7 +56,7 @@
   justify-content: center;
   align-items: center;
   gap: 8px;
-  border-radius: 100px;
+  border-radius: 12px;
   color: $gray50;
   text-align: center;
   outline: none;
@@ -71,7 +71,7 @@
   justify-content: center;
   align-items: center;
   gap: 8px;
-  border-radius: 100px;
+  border-radius: 12px;
   background-color: $blue60;
   color: $white;
   outline: none;


### PR DESCRIPTION
### 🔎 작업 내용
 - [x] 사용자 위치 정보로 강좌 지역 필터 세팅

### 📸 스크린샷
![image](https://github.com/user-attachments/assets/2c2ca919-594d-4107-afef-ebb3854ab72a)

### :loudspeaker: 전달사항
 - 지도 홈에서 사용자 위치를 읽고, state와 localStorage에 저장해둔 지역 코드를 강좌 목록 필터링의 기본 값으로 설정하여 사용자 편의 증대, 검색 결과도 사용자 지역에 해당하는 시설 출력
